### PR TITLE
Update nf-teams plugin version to 0.1.1

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -251,7 +251,7 @@ plugins {
     id 'nf-cgroup-metrics@1.0.1'
     id 'nf-cmgg@0.1.0'
     id 'nf-schema@2.6.1'
-    id 'nf-teams@0.1.0'
+    id 'nf-teams@0.1.1'
 }
 
 validation {


### PR DESCRIPTION
This fixes the `teams.enabled` config option. The plugin doesn't automatically try to use the teams notification functionality now