### PR TITLE
Revert nf-cmgg/configs back to nf-core/configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `apple` profile to enable the use of Apple containers.
 - Drop `hook_url` parameter. To configure messaging services, use a custom config in tandem with the `nf-teams`/`nf-slack` plugin instead.
 - Drop `run_coverage` and add `qc_mode` parameter. Thorough coveage analysis is now included in the `qc_mode` parameter, which can be set to `basic` or `full`. Basic QC includes samtools flagstat, idxstats and mosdepth. Full QC includes samtools stats, samtools coverage, riker metrics and panel coverage in addition to basic QC.
+- Revert the default configs base to the nf-core configs in preparation of converting nf-cmgg/configs to a private repo
 
 ## 3.0.2
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -16,7 +16,6 @@ params {
 
     // Input data
     input                      = "${projectDir}/tests/inputs/test.yml"
-    custom_config_base         = null
 }
 
 process {

--- a/main.nf
+++ b/main.nf
@@ -44,24 +44,6 @@ params {
     // Directory containing gene list bed files for granular coverage analysis
     genelists: Path?
 
-    // Git commit id for Institutional configs.
-    custom_config_version: String = 'main'
-
-    // Base directory for custom configs.
-    custom_config_base: String = 'https://raw.githubusercontent.com/nf-cmgg/configs/main'
-
-    // Institutional config name.
-    config_profile_name: String?
-
-    // Institutional config description.
-    config_profile_description: String?
-
-    // Institutional config contact information.
-    config_profile_contact: String?
-
-    // Institutional config URL link.
-    config_profile_url: String?
-
     // Display version and exit.
     version: Boolean = false
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,8 +16,8 @@ params {
     pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/'
     trace_report_suffix          = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
 
-    custom_config_version        = 'main'
-    custom_config_base           = "https://raw.githubusercontent.com/nf-cmgg/configs/${params.custom_config_version}"
+    custom_config_version        = 'master'
+    custom_config_base           = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 
     outdir                       = './results'
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -86,14 +86,14 @@
                 "custom_config_version": {
                     "type": "string",
                     "description": "Git commit id for Institutional configs.",
-                    "default": "main",
+                    "default": "master",
                     "hidden": true,
                     "fa_icon": "fas fa-users-cog"
                 },
                 "custom_config_base": {
                     "type": "string",
                     "description": "Base directory for custom configs.",
-                    "default": "https://raw.githubusercontent.com/nf-cmgg/configs/main",
+                    "default": "https://raw.githubusercontent.com/nf-core/configs/master",
                     "hidden": true,
                     "help_text": "If you're running offline, Nextflow will not be able to fetch the custom config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell Nextflow where to find them with this parameter.",
                     "fa_icon": "fas fa-users-cog"


### PR DESCRIPTION
Revert back to nf-core/configs as the default. This will ensure that the pipeline will start working for everyone again and will prevent the pipeline from breaking when we make our configs private